### PR TITLE
Add FILE_STORAGE_LOCATOR env var for Windows containers

### DIFF
--- a/Olsson.GET.Managers/Runs/RunManager.cs
+++ b/Olsson.GET.Managers/Runs/RunManager.cs
@@ -1063,7 +1063,8 @@ namespace Olsson.GET.Managers.Runs
                         { "MODEL_ID", run.ModelID.ToString() },
                         { "DOTNET_ENVIRONMENT", ConfigurationHelper.GetEnvironment() }, // i'm guessing this isn't being used at all because the linux containers are small and simple
                         { "STORAGE_ACCOUNT", ConfigurationHelper.AppSettings.AzureStorageAccountName},
-                        { "SAS_TOKEN", sasToken}
+                        { "SAS_TOKEN", sasToken},
+                        { "FILE_STORAGE_LOCATOR", run.FileStorageLocator }
                     };
 
                     containerAccessor.StartAzureContainer(run.FileStorageLocator,


### PR DESCRIPTION
This change adds the FILE_STORAGE_LOCATOR environment variable to the container startup configuration for Windows-based input containers. This allows the container to upload generated files to the correct blob storage path, enabling the analysis container to retrieve them.